### PR TITLE
Allow overriding --validators-dir and --secrets-dir; Disable the RPC service by default

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,6 +12,9 @@ beacon_node_build_script_path: '{{ beacon_node_path }}/build.sh'
 beacon_node_user: 'nimbus'
 beacon_node_group: 'staff'
 
+beacon_node_validators_dir: ""
+beacon_node_secrets_dir: ""
+
 beacon_node_build_timer_enabled: true
 beacon_node_build_timer_timeout: 3600
 beacon_node_build_frequency: 'daily'
@@ -35,10 +38,17 @@ beacon_node_discovery_port: 9000
 beacon_node_listening_port: 9000
 
 # Scraping of metrics done via VPN. Protected by firewall.
+beacon_node_metrics_enabled: true
 beacon_node_metrics_address: '0.0.0.0'
 beacon_node_metrics_port: 9200
+
+# The JSON-RPC service is disabled because this is a legacy
+# functionality that will be removed from Nimbus eventually
+beacon_node_rpc_enabled: false
 beacon_node_rpc_address: '127.0.0.1'
 beacon_node_rpc_port: 9900
+
+beacon_node_rest_enabled: true
 beacon_node_rest_address: '127.0.0.1'
 beacon_node_rest_port: 5052
 

--- a/templates/beacon-node.service.j2
+++ b/templates/beacon-node.service.j2
@@ -12,6 +12,12 @@ Restart=on-failure
 ExecStart={{ beacon_node_repo_path }}/build/nimbus_beacon_node \
     --network={{ beacon_node_network }} \
     --data-dir='{{ beacon_node_data_path }}/{{ beacon_node_data_folder }}' \
+{% if beacon_node_validators_dir != "" %}
+    --validators-dir='{{ beacon_node_validators_dir }}' \
+{% endif %}
+{% if beacon_node_secrets_dir != "" %}
+    --secrets-dir='{{ beacon_node_secrets_dir }}' \
+{% endif %}
 {% for url in beacon_node_web3_urls | mandatory %}
     --web3-url={{ url | mandatory }} \
 {% endfor %}
@@ -25,15 +31,21 @@ ExecStart={{ beacon_node_repo_path }}/build/nimbus_beacon_node \
     --insecure-netkey-password=true \
     --subscribe-all-subnets={{ beacon_node_subscribe_all | to_json }} \
     --doppelganger-detection={{ beacon_node_doppelganger_detection | to_json }} \
-    --rpc \
+    --rpc={{ beacon_node_rpc_enabled | to_json }} \
+{% if beacon_node_rpc_enabled %}
     --rpc-address={{ beacon_node_rpc_address }} \
     --rpc-port={{ beacon_node_rpc_port }} \
-    --rest \
+{% endif %}
+    --rest={{ beacon_node_rest_enabled | to_json }} \
+{% if beacon_node_rest_enabled %}
     --rest-address={{ beacon_node_rest_address }} \
     --rest-port={{ beacon_node_rest_port }} \
-    --metrics \
+{% endif %}
+    --metrics={{ beacon_node_metrics_enabled | to_json }} \
+{% if beacon_node_metrics_enabled %}
     --metrics-address={{ beacon_node_metrics_address }} \
     --metrics-port={{ beacon_node_metrics_port }}
+{% endif %}
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Nowadays, we should be using REST instead of the legacy JSON-RPC service