### PR TITLE
add beacon_node_light_client_data_* variables

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -71,6 +71,11 @@ beacon_node_rest_enabled: true
 beacon_node_rest_address: '127.0.0.1'
 beacon_node_rest_port: 5052
 
+# Light client data
+beacon_node_light_client_data_enabled: false
+beacon_node_light_client_data_serve: false
+beacon_node_light_client_data_import: 'none'
+
 # How many hardware threads to use
 beacon_node_threads: 1
 

--- a/templates/beacon-node.service.j2
+++ b/templates/beacon-node.service.j2
@@ -60,6 +60,10 @@ ExecStart={{ beacon_node_repo_path }}/build/nimbus_beacon_node \
 {% for pubkey in beacon_node_validator_monitor_pubkeys %}
     --validator-monitor-pubkey={{ pubkey }} \
 {% endfor %}
+{% if beacon_node_light_client_data_enabled %}
+    --serve-light-client-data={{ beacon_node_light_client_data_serve | to_json }} \
+    --import-light-client-data={{ beacon_node_light_client_data_import }} \
+{% endif %}
     --num-threads={{ beacon_node_threads }}
 
 [Install]


### PR DESCRIPTION
To control the `--serve-light-client-data` and
`--import-light-client-data` flags.

Note: These new flags are only available on `unstable` at this time. `stable` does not support them yet.