### PR TITLE
renamed BN light client data options

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -70,7 +70,7 @@ beacon_node_rest_port: 5052
 # Light client data
 beacon_node_light_client_data_enabled: false
 beacon_node_light_client_data_serve: false
-beacon_node_light_client_data_import: 'none'
+beacon_node_light_client_data_import_mode: 'none'
 
 # How many hardware threads to use
 beacon_node_threads: 1

--- a/templates/beacon-node.service.j2
+++ b/templates/beacon-node.service.j2
@@ -60,8 +60,8 @@ ExecStart={{ beacon_node_repo_path }}/build/nimbus_beacon_node \
     --validator-monitor-pubkey={{ pubkey }} \
 {% endfor %}
 {% if beacon_node_light_client_data_enabled %}
-    --serve-light-client-data={{ beacon_node_light_client_data_serve | to_json }} \
-    --import-light-client-data={{ beacon_node_light_client_data_import }} \
+    --light-client-data-serve={{ beacon_node_light_client_data_serve | to_json }} \
+    --light-client-data-import-mode={{ beacon_node_light_client_data_import_mode }} \
 {% endif %}
     --num-threads={{ beacon_node_threads }}
 {% for extra_flag in beacon_node_extra_flags %}


### PR DESCRIPTION
Adjusts for the new names of BN light client data config options
* `--serve-light-client-data` --> `--light-client-data-serve`
* `--import-light-client-data` --> `--light-client-data-import-mode`
