### PR TITLE
add beacon_node_light_client_data_max_periods

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -71,6 +71,7 @@ beacon_node_rest_port: 5052
 beacon_node_light_client_data_enabled: false
 beacon_node_light_client_data_serve: false
 beacon_node_light_client_data_import_mode: 'none'
+beacon_node_light_client_data_max_periods: -1 # -1 to use default
 
 # How many hardware threads to use
 beacon_node_threads: 1

--- a/templates/beacon-node.service.j2
+++ b/templates/beacon-node.service.j2
@@ -63,6 +63,9 @@ ExecStart={{ beacon_node_repo_path }}/build/nimbus_beacon_node \
 {% if beacon_node_light_client_data_enabled %}
     --light-client-data-serve={{ beacon_node_light_client_data_serve | to_json }} \
     --light-client-data-import-mode={{ beacon_node_light_client_data_import_mode }} \
+{% if beacon_node_light_client_data_max_periods >= 0 %}
+    --light-client-data-max-periods={{ beacon_node_light_client_data_max_periods }} \
+{% endif %}
 {% endif %}
     --num-threads={{ beacon_node_threads }}
 {% for extra_flag in beacon_node_extra_flags %}


### PR DESCRIPTION
Allows overriding `--light-client-data-max-periods` as introduced in
https://github.com/status-im/nimbus-eth2/pull/3799
