### PR TITLE
service: add allow restart parameter

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -15,7 +15,11 @@ beacon_node_validators_path: '{{ beacon_node_data_path }}/validators'
 beacon_node_binary_path: '{{ beacon_node_bin_path }}/nimbus_beacon_node'
 
 # Ability to prevernt restarts after service changes.
-beacon_node_service_restart: false
+# This is higher priority, than force_restart.
+beacon_node_service_allow_restart: true
+# Force restart service on each ansible playbook run
+beacon_node_service_force_restart: false
+
 # Should be: nextPowerOfTwo(number_of_validators + 1024)
 beacon_node_service_nofile_limit: 16384
 beacon_node_user: 'nimbus'

--- a/tasks/service.yml
+++ b/tasks/service.yml
@@ -14,13 +14,15 @@
   register: beacon_node_service_definition
 
 - name: Reload and restart the service
-  systemd:
+  systemd_service:
     name: '{{ beacon_node_service_name }}.service'
     enabled: true
     daemon_reload: true
     state: |-
       {{ (
+        beacon_node_service_allow_restart
+      and (
         beacon_node_config_file.changed or
         beacon_node_service_definition.changed or
-        beacon_node_service_restart
-      ) | ternary("restarted", "started") }}
+        beacon_node_service_force_restart
+      )) | ternary("restarted", "started") }}

--- a/tasks/validators.yml
+++ b/tasks/validators.yml
@@ -15,6 +15,6 @@
       debug: msg='Deployed {{ dist_validators_deployed }} validators'
 
     - name: 'Restart beacon node service'
-      service:
+      systemd_service:
         name: '{{ beacon_node_service_name }}.service'
-        state: 'restarted'
+        state: '{{ beacon_node_service_allow_restart | ternary("restarted", "started") }}'


### PR DESCRIPTION
Automated service restart can be risky on certain fleets with real validators.
Let's have an option to prohibit it.