### PR TITLE
config: add explicit quic-port option

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -73,6 +73,8 @@ beacon_node_public_address: '{{ ansible_host }}'
 beacon_node_max_peers: 160
 beacon_node_discovery_port: 9000
 beacon_node_listening_port: 9000
+beacon_node_quic_enabled: false
+beacon_node_quic_port: 9001
 
 # Scraping of metrics done via VPN. Protected by firewall.
 beacon_node_metrics_enabled: true

--- a/templates/config.toml.j2
+++ b/templates/config.toml.j2
@@ -19,6 +19,9 @@ log-level = {{ beacon_node_log_level | to_json }}
 nat = "extip:{{ beacon_node_public_address }}"
 tcp-port = {{ beacon_node_listening_port }}
 udp-port = {{ beacon_node_discovery_port }}
+{% if beacon_node_quic_enabled %}
+quic-port = {{ beacon_node_quic_port }}
+{% endif %}
 max-peers = {{ beacon_node_max_peers }}
 
 ### Exec Layer


### PR DESCRIPTION
https://github.com/status-im/nimbus-eth2/commit/4a4ac9c1d1a230eaa0ed83fb2ab85acd8df35391 enables QUIC by default on a fixed port 9001, which collides with sequential tcp/udp port schemes on multi-node hosts. 

Render quic-port in the Network section when enabled.

Disabled by default since older builds reject the unknown config key ("Unexpected field") on startup.